### PR TITLE
start batching

### DIFF
--- a/docs/src/tutorials/gpu_bayesian.md
+++ b/docs/src/tutorials/gpu_bayesian.md
@@ -213,6 +213,7 @@ following is a GPU-accelerated uncertainty quanitified estimate of the expectati
 of the solution:
 
 ```julia
-# batchmode = EnsembleGPUArray() #where to pass this?
-sol = solve(exprob, Koopman(),batch=100,quadalg = CubaSUAVE())
+sm = SystemMap(prob1, Tsit5(),EnsembleCPUArray(),extra_keyword_needed=nothing)
+exprob = ExpectationProblem(sm, g, h, gd; nout=1)
+sol = solve(exprob, Koopman(),batch=1000,quadalg = CubaSUAVE())
 ```

--- a/src/system_utils.jl
+++ b/src/system_utils.jl
@@ -13,6 +13,10 @@ struct SystemMap{DT <: DiffEqBase.DEProblem, A, K}
     args::A
     kwargs::K
 end
+function SystemMap(prob, alg::OrdinaryDiffEqAlgorithm,
+                   ensemblealg::SciMLBase.EnsembleAlgorithm; kwargs...)
+    SystemMap(prob, (alg, ensemblealg), kwargs)
+end
 SystemMap(prob, args...; kwargs...) = SystemMap(prob, args, kwargs)
 
 function (sm::SystemMap{DT})(u0, p) where {DT}


### PR DESCRIPTION
Specifying a batching algorithm in SystemMap currently leads to method ambiguities.
Maybe specify `args` more explicitly as a solver and an ensemble solver?
```jl
struct SystemMap{DT <: DiffEqBase.DEProblem, A, K}
    prob::DT
    args::A
    kwargs::K
end
```