### PR TITLE
Support SciMLBase v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLExpectations"
 uuid = "afe9f18d-7609-4d0e-b7b7-af0cb72b8ea8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "2.4.0"
+version = "2.4.1"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -42,7 +42,7 @@ RecursiveArrayTools = "3, 4"
 Reexport = "0.2, 1.0"
 ReferenceTests = "0.10"
 SafeTestsets = "0.1"
-SciMLBase = "2.104"
+SciMLBase = "2.104, 3.1"
 StaticArrays = "1"
 Statistics = "1"
 StochasticDiffEq = "6"


### PR DESCRIPTION
## Summary

Courtesy PR for the SciMLBase v3 release.

Extend `SciMLBase` compat to include v3.1 (keep the existing lower bound and v2 support). No code changes required — a grep of `src/` and `test/` found no references to the SciMLBase v3 breaking surface (`u_modified!`, removed `DEProblem` type alias, 3-arg ensemble `prob_func`, single-int non-scalar timeseries `sol[i]` indexing, or removed getproperty aliases like `.destats` / `.minimizer`).

## Known limitation

Local tests cannot be run: `Pkg.resolve()` fails on any env containing SciMLBase 3.1 because `OrdinaryDiffEq` in the registry still pins `RecursiveArrayTools ≤ 3.54` while SciMLBase 3.1 requires RAT v4. Expect CI on this PR to fail at the `Pkg.add` step with an unsatisfiable resolution error until upstream OrdinaryDiffEq releases a RAT-v4-compatible version; re-running afterward should go green without further edits.

## Context

Part of the SciMLBase v3 ecosystem sweep — see SciML/DiffEqCallbacks.jl#300 and SciML/DiffEqParamEstim.jl#290 for the reference patterns for code-side changes.

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)