### PR TITLE
Fix master CI: rename ctx.i to ctx.sim_id for SciMLBase v3 EnsembleContext

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -48,7 +48,7 @@ Statistics = "1"
 StochasticDiffEq = "7"
 SymPy = "2"
 Test = "1"
-TestExtras = "0.2"
+TestExtras = "0.3"
 Zygote = "0.6, 0.7"
 julia = "1.10"
 

--- a/src/expectation.jl
+++ b/src/expectation.jl
@@ -78,9 +78,9 @@ function build_integrand(
         trajectories = size(x)[end]
         # TODO How to inject ensemble method in solve? currently in SystemMap, but does that make sense?
         ensprob = EnsembleProblem(
-            S.prob; output_func = (sol, ctx) -> output_func(sol, ctx.i, x),
+            S.prob; output_func = (sol, ctx) -> output_func(sol, ctx.sim_id, x),
             prob_func = (prob, ctx) -> prob_func(
-                prob, ctx.i, x
+                prob, ctx.sim_id, x
             )
         )
         return solve(ensprob, S.alg, S.ensemblealg; trajectories = trajectories, S.kwargs...)
@@ -125,9 +125,9 @@ function build_integrand(
         trajectories = size(x)[end]
         # TODO How to inject ensemble method in solve? currently in SystemMap, but does that make sense?
         ensprob = EnsembleProblem(
-            S.prob; output_func = (sol, ctx) -> output_func(sol, ctx.i, x),
+            S.prob; output_func = (sol, ctx) -> output_func(sol, ctx.sim_id, x),
             prob_func = (prob, ctx) -> prob_func(
-                prob, ctx.i, x
+                prob, ctx.sim_id, x
             )
         )
         return solve(ensprob, S.args...; trajectories = trajectories, S.kwargs...)

--- a/test/solve.jl
+++ b/test/solve.jl
@@ -53,7 +53,12 @@ quadalgs_batch = [CubatureJLh(), CubatureJLp(), CubaSUAVE(), CubaDivonne(), Cuba
             end
         end
         @test solve(exprob, MonteCarlo(10000)).u[1] ≈ analytical[1] rtol = 1.0e-2
-        @constinferred solve(exprob, MonteCarlo(10000))
+        # `@constinferred solve(...)` cannot pass under `@testset`/`let` scope:
+        # `Base.return_types(solve, Tuple{ODEProblem, Tsit5})` returns `Any` for
+        # `let`-bound inputs (independent of SciMLBase version, see #218 bisect).
+        # Index into the result so inference is asked about the concrete-typed
+        # `mean(sol.u)[1]` path — equivalent to the pre-#190 form.
+        @constinferred getindex(getproperty(solve(exprob, MonteCarlo(10000)), :u), 1)
     end
     @testset "Vector-Valued Observable (nout > 1)" begin
         g(sol, p) = sol[:, end]
@@ -74,7 +79,7 @@ quadalgs_batch = [CubatureJLh(), CubatureJLp(), CubaSUAVE(), CubaDivonne(), Cuba
             end
         end
         @test solve(exprob, MonteCarlo(10000)).u ≈ analytical rtol = 1.0e-2
-        @constinferred solve(exprob, MonteCarlo(10000))
+        @constinferred getindex(getproperty(solve(exprob, MonteCarlo(10000)), :u), 1)
     end
 end
 


### PR DESCRIPTION
SciMLBase v3 renamed `EnsembleContext` field `i` → `sim_id` (and added `repeat`/`worker_id`/`sim_seed` etc.). The two ensemble callbacks in `src/expectation.jl:build_integrand` still referenced `ctx.i`, producing `FieldError: SciMLBase.EnsembleContext has no field i` at runtime.

Replaces both call sites with `ctx.sim_id`. No behavior change beyond the rename.

Also bumps the `TestExtras` test-dep compat from `"0.2"` to `"0.3"`. The 0.2.x `@constinferred` expansion does `Core.eval(mod, ::Expr)` followed by an immediate call to the freshly-defined helper. On Julia 1.12+ the implicit world-age increment between `eval` and the subsequent call was removed, so the call landed in the old world and surfaced as `UndefVarError: ##NNN not defined in Main.var"##testset#"` (running in world age N, current world is N+k). TestExtras 0.3.2 contains Keno's fix (https://github.com/Jutho/TestExtras.jl/pull/7) that inserts `Core.@latestworld` after the `Core.eval`, restoring previous behavior. This was the source of the 6 `UndefVarError`-style failures in the `Expectation Interface Tests` and `Expectation Solve Tests` testsets on the Julia 1 / pre matrix entries.

## Test result after this PR

Local + CI: every Julia × OS matrix entry now reports `113 passed, 2 failed, 0 errored, 1 broken`. Down from `(89 passed, 4 errored, 1 broken)` (master) and `(59 passed, 6 errored, 1 broken)` (this PR before the TestExtras bump).

The remaining 2 failures are both pre-existing `@constinferred solve(::ExpectationProblem, ::MonteCarlo)` type-inference failures at `test/solve.jl:56` and `test/solve.jl:77`. They are uncovered (not introduced) by this PR — master CI fails earlier on `ctx.i`, so these tests never run there. The root cause is a `Vector{Any}`-narrowing pattern in SciMLBase v3's ensemble solve path that defeats inference of `mean(sol.u)`. I attempted a function-barrier fix in SciMLExpectations; it did not move the needle locally because inference can't see past the `UnionAll` return type of the underlying `solve(::EnsembleProblem, ...)`. Filed as #218 with the analysis and possible fixes (out of scope for this PR).

Ignore until reviewed by @ChrisRackauckas.