### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
       - "/docs"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -13,20 +13,9 @@ on:
 jobs:
   test:
     if: false
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.17.0 
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,3 +1,7 @@
+[default.extend-identifiers]
+# StochasticDiffEq.jl solver (Lamba–Rackauckas–Tretyakov Euler–Maruyama)
+LambaEM = "LambaEM"
+
 [default.extend-words]
 # Julia-specific functions
 indexin = "indexin"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

This PR converts the remaining inline CI workflows to the centralized SciML reusable workflows (`@v1`), with `secrets: "inherit"` on every caller. Tests and Documentation were already central callers.

## Converted (inline -> central)
- **FormatCheck.yml (Runic)**: `fredrikekre/runic-action@v1` -> `SciML/.github/.github/workflows/runic.yml@v1`
- **SpellCheck.yml**: `crate-ci/typos@v1.17.0` -> `SciML/.github/.github/workflows/spellcheck.yml@v1`
- **Downgrade.yml**: inline -> `SciML/.github/.github/workflows/downgrade.yml@v1` (`julia-version: "1.10"`, `skip: "Pkg,TOML"`), preserving the existing `if: false` disable on the job.

## Unchanged
- **Tests.yml** and **Documentation.yml** were already `@v1` central callers with `secrets: "inherit"` (version × os matrix preserved as-is).
- **TagBot.yml** left untouched.

## Cleanup
- `dependabot.yml`: removed the `crate-ci/typos` version ignore (no longer relevant with the central spellcheck caller); removed `/test` from the `julia` block since there is no `test/Project.toml` (test deps live in the main Project.toml extras). Kept `/` and `/docs`.
- No `CompatHelper.yml` present.

## Typos
- Typos run is clean (exit 0). 0 prose fixes applied. The only finding (`LambaEM`) is a real StochasticDiffEq.jl solver name, added to `.typos.toml` as an allowed identifier rather than edited.

## Runic
- Runic ran with no changes (repo was already Runic-clean from the prior inline check).

## Note on branch protection
Job/check names change with the central callers (e.g. Runic, Spell Check, Downgrade now run inside reusable workflows). Branch-protection required-check names may need updating to match the new check names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)