### PR TITLE
Remove unused SymPy test dependency (fixes ubuntu Core CI PyCall build failure)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -46,7 +46,6 @@ SciMLTesting = "1"
 StaticArrays = "1.9.14"
 Statistics = "1.10.0"
 StochasticDiffEq = "7"
-SymPy = "2"
 Test = "1"
 TestExtras = "0.3"
 Zygote = "0.7.5"
@@ -69,9 +68,8 @@ ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
-SymPy = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestExtras = "5ed8adda-3752-4e41-b88a-e8b09835ee3a"
 
 [targets]
-test = ["Test", "Aqua", "SafeTestsets", "SciMLTesting", "TestExtras", "PkgBenchmark", "BenchmarkTools", "ReferenceTests", "SymPy", "Random", "OrdinaryDiffEq", "ComponentArrays", "ForwardDiff", "Integrals", "Cubature", "Cuba", "FiniteDiff", "RecursiveArrayTools", "StochasticDiffEq"]
+test = ["Test", "Aqua", "SafeTestsets", "SciMLTesting", "TestExtras", "PkgBenchmark", "BenchmarkTools", "ReferenceTests", "Random", "OrdinaryDiffEq", "ComponentArrays", "ForwardDiff", "Integrals", "Cubature", "Cuba", "FiniteDiff", "RecursiveArrayTools", "StochasticDiffEq"]


### PR DESCRIPTION
## Summary

Removes the unused `SymPy` test dependency, which was taking down the entire **Core** test group on `ubuntu-latest` for Julia `1` and `lts`.

## Root cause

`SymPy` was declared as a test dependency (in `[deps]` extras, `[compat]`, and the `test` target) but is **not referenced anywhere** in the test suite or source. `SymPy` v2 pulls in `PyCall`, which fails to build/precompile on the `ubuntu-latest` CI runners because no `libpython` is available:

```
Error building `PyCall`:
ERROR: LoadError: Couldn't find libpython; check your PYTHON environment variable.
```

Because `Pkg.test` builds all test-target dependencies, this failure aborted the Core group before any test ran. The macOS and Windows Core jobs were unaffected (PyCall builds there), which is why only the `ubuntu-latest` checks were red. This is pre-existing — it reproduces on the parent commit (before the SciMLTesting v1.2 conversion) and the Documentation build has been separately red since well before that.

## Fix

Drop `SymPy` from `[deps]` extras, `[compat]`, and the `test` target. Nothing in the package uses it.

## Local verification (Julia 1.12.6, Linux — same as the failing `julia 1` ubuntu job)

After the change, `Pkg.test()` resolves the Core test environment with **no PyCall / no SymPy**, precompiles cleanly, and all four Core test files pass:

```
Core/differentiation.jl | 1   1
Core/interface.jl       | 54  54
Core/processnoise.jl    | 1   1
Core/solve.jl           | 50  50
Testing SciMLExpectations tests passed
```

(`Pkg.test` exited with code 0.)

## Out of scope

The separate `Documentation` build failure is a genuine `@example` `BoundsError` in `docs/src/tutorials/optimization_under_uncertainty.md` (real code/dependency breakage, pre-existing) and is not addressed here.

---
Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
