### PR TITLE
Document public API coverage

### DIFF
--- a/docs/src/manual/algorithms.md
+++ b/docs/src/manual/algorithms.md
@@ -3,4 +3,7 @@
 ```@docs
 MonteCarlo
 Koopman
+NonfusedAD
+PrefusedAD
+PostfusedAD
 ```

--- a/docs/src/manual/solve.md
+++ b/docs/src/manual/solve.md
@@ -3,4 +3,7 @@
 ```@docs
 solve(prob::ExpectationProblem, expalg::MonteCarlo)
 solve(prob::ExpectationProblem, expalg::Koopman)
+build_integrand
+centralmoment
+SciMLExpectations.ExpectationSolution
 ```

--- a/src/distribution_utils.jl
+++ b/src/distribution_utils.jl
@@ -1,9 +1,34 @@
 """
-`GenericDistribution(d, ds...)`
+    GenericDistribution(pdf_func, rand_func, lb, ub)
+    GenericDistribution(d::Distributions.Sampleable, ds...)
 
-Defines a generic distribution that just wraps functions for pdf function, rand and bounds.
-User can use this for define any arbitrary joint pdf. Included b/c Distributions.jl Product
-method of mixed distributions are type instable.
+Represent a distribution by its density, sampler, and integration bounds.
+
+`GenericDistribution` can be used for arbitrary joint densities and for products of
+sampleable distributions. The `Distributions.Sampleable` constructor builds a joint
+density from independent one-dimensional distributions without relying on
+`Distributions.Product`.
+
+## Arguments
+
+  - `pdf_func`: Function called as `pdf_func(x)` to evaluate the density.
+  - `rand_func`: Zero-argument function that returns one sample.
+  - `lb`: Lower integration bound.
+  - `ub`: Upper integration bound.
+  - `d, ds...`: Independent sampleable distributions used to build a joint
+    distribution.
+
+## Fields
+
+  - `pdf_func`: Stored density function.
+  - `rand_func`: Stored sampler.
+  - `lb`: Stored lower bound.
+  - `ub`: Stored upper bound.
+
+## Returns
+
+A distribution-like object supporting `pdf`, `rand`, `minimum`, `maximum`, and
+`extrema`.
 """
 struct GenericDistribution{TF, TRF, TLB, TUB}
     pdf_func::TF

--- a/src/expectation.jl
+++ b/src/expectation.jl
@@ -1,9 +1,62 @@
 abstract type AbstractExpectationADAlgorithm end
+
+"""
+    NonfusedAD()
+
+Use separate quadrature solves for the primal integral and parameter pullback in
+Koopman expectation solves.
+
+## Returns
+
+A `NonfusedAD` automatic differentiation algorithm for `Koopman`.
+"""
 struct NonfusedAD <: AbstractExpectationADAlgorithm end
+
+"""
+    PrefusedAD()
+    PrefusedAD(norm_partials::Bool)
+
+Fuse the primal integrand and parameter partials before the pullback in Koopman
+expectation solves.
+
+## Arguments
+
+  - `norm_partials`: Whether fused quadrature norms should include partial terms in
+    implementations that use this option. Defaults to `true`.
+
+## Fields
+
+  - `norm_partials`: Stored partial-norm flag.
+
+## Returns
+
+A `PrefusedAD` automatic differentiation algorithm for `Koopman`.
+"""
 struct PrefusedAD <: AbstractExpectationADAlgorithm
     norm_partials::Bool
 end
 PrefusedAD() = PrefusedAD(true)
+
+"""
+    PostfusedAD()
+    PostfusedAD(norm_partials::Bool)
+
+Fuse the primal integrand and parameter partials during the pullback after the
+primal Koopman expectation solve.
+
+## Arguments
+
+  - `norm_partials`: Whether fused quadrature norms should include partial terms in
+    implementations that use this option. Defaults to `true`.
+
+## Fields
+
+  - `norm_partials`: Stored partial-norm flag.
+
+## Returns
+
+A `PostfusedAD` automatic differentiation algorithm for `Koopman`.
+"""
 struct PostfusedAD <: AbstractExpectationADAlgorithm
     norm_partials::Bool
 end
@@ -12,9 +65,26 @@ PostfusedAD() = PostfusedAD(true)
 abstract type AbstractExpectationAlgorithm <: SciMLBase.AbstractDEAlgorithm end
 
 """
-```julia
-Koopman()
-```
+    Koopman()
+    Koopman(sensealg::AbstractExpectationADAlgorithm)
+
+Solve expectations by quadrature over the uncertainty domain.
+
+`Koopman` builds an `Integrals.jl` integral problem for the observable and
+distribution in an `ExpectationProblem`. The optional `sensealg` selects the
+automatic differentiation strategy used by differentiable expectation solves.
+
+## Arguments
+
+  - `sensealg`: Automatic differentiation strategy. Defaults to `NonfusedAD()`.
+
+## Fields
+
+  - `sensealg`: Stored automatic differentiation strategy.
+
+## Returns
+
+A `Koopman` expectation algorithm for `solve`.
 """
 struct Koopman{TS} <:
     AbstractExpectationAlgorithm where {TS <: AbstractExpectationADAlgorithm}
@@ -23,15 +93,50 @@ end
 Koopman() = Koopman(NonfusedAD())
 
 """
-```julia
-MonteCarlo(trajectories::Int)
-```
+    MonteCarlo(trajectories::Int)
+
+Estimate expectations by averaging random samples from the uncertainty
+distribution.
+
+## Arguments
+
+  - `trajectories`: Number of samples or ensemble trajectories to use.
+
+## Fields
+
+  - `trajectories`: Stored sample or trajectory count.
+
+## Returns
+
+A `MonteCarlo` expectation algorithm for `solve`.
 """
 struct MonteCarlo <: AbstractExpectationAlgorithm
     trajectories::Int
 end
 
-# Builds integrand for arbitrary functions
+"""
+    build_integrand(prob::ExpectationProblem, expalg::Koopman, mid, p, batch)
+
+Construct the integral function used by a Koopman expectation solve.
+
+This helper lowers an `ExpectationProblem` to the `IntegralFunction` or
+`BatchIntegralFunction` consumed by `Integrals.jl`. It is primarily useful for
+advanced users who need to inspect or customize the integrand before integration.
+
+## Arguments
+
+  - `prob`: Expectation problem to lower.
+  - `expalg`: Koopman expectation algorithm.
+  - `mid`: Midpoint of the integration domain, used to infer output shape for
+    batched integrands.
+  - `p`: Parameters passed to the integrand.
+  - `batch`: `nothing` for scalar integration or an integer batch size.
+
+## Returns
+
+An `IntegralFunction` for unbatched integration or a `BatchIntegralFunction` for
+batched system-map integration.
+"""
 function build_integrand(prob::ExpectationProblem, ::Koopman, mid, p, ::Nothing)
     @unpack g, d = prob
     function integrand_koopman(x, p)
@@ -369,12 +474,18 @@ The central moments are computed using the binomial expansion:
 where `μ = E[X]` is the mean.
 
 ## Arguments
+
 - `n`: The highest order central moment to compute (n ≥ 1)
 - `exprob`: An `ExpectationProblem` with a scalar-valued observable
 - `expalg`: The algorithm to use (`Koopman()` or `MonteCarlo(trajectories)`)
 - `kwargs...`: Additional keyword arguments passed to `solve`
 
-## Example
+## Returns
+
+A vector of central moments from order `1` through order `n`.
+
+## Examples
+
 ```julia
 using SciMLExpectations, Distributions
 

--- a/src/problem_types.jl
+++ b/src/problem_types.jl
@@ -1,23 +1,42 @@
 abstract type AbstractUncertaintyProblem end
 
 """
-```julia
-ExpectationProblem(S, g, h, pdist, params)
-ExpectationProblem(g, pdist, params)
-ExpectationProblem(sm::SystemMap, g, h, d)
-```
+    ExpectationProblem(S, g, h, d, params)
+    ExpectationProblem(g, d, params; nout = nothing)
+    ExpectationProblem(sm::SystemMap, g, h, d; nout = nothing)
+    ExpectationProblem(sm::ProcessNoiseSystemMap, g, h; nout = nothing)
 
-Defines ∫ g(S(h(x,u0,p)))*f(x)dx
+Represent an expectation of an observable over an uncertainty distribution.
+
+An `ExpectationProblem` defines the data needed to compute an integral of the form
+`integral g(S(u, p), p) * pdf(d, x) dx`, where `h(x, u0, p)` maps uncertain
+inputs into initial conditions and parameters for the system map `S`. The
+function-only constructor uses identity maps for `S` and `h`.
 
 ## Arguments
 
-Let 𝕏 = uncertainty space, 𝕌 = Initial condition space, ℙ = model parameter space
+  - `S`: System map called as `S(u, p)`.
+  - `g`: Observable called as `g(u, p)` for function problems or `g(sol, p)` for
+    system maps.
+  - `h`: Covariate map called as `h(x, u0, p)`.
+  - `d`: Distribution of uncertain inputs. It must support the operations needed by
+    the chosen expectation algorithm, such as `pdf`, `rand`, and `extrema`.
+  - `params`: Parameters passed to the observable and integration problem.
+  - `sm`: A `SystemMap` or `ProcessNoiseSystemMap`.
+  - `nout`: Deprecated and unused.
 
-  - S: 𝕌 × ℙ → 𝕌 also known as system map.
-  - g: 𝕌 × ℙ → ℝⁿᵒᵘᵗ also known as the observables or output function.
-  - h: 𝕏 × 𝕌 × ℙ → 𝕌 × ℙ also known as covariate function.
-  - pdf(d,x): 𝕏 → ℝ the uncertainty distribution of the initial states.
-  - params
+## Fields
+
+  - `S`: Stored system map.
+  - `g`: Stored observable.
+  - `h`: Stored covariate map.
+  - `d`: Stored uncertainty distribution.
+  - `params`: Stored parameters.
+
+## Returns
+
+An `ExpectationProblem` that can be solved with `solve(prob, Koopman())` or
+`solve(prob, MonteCarlo(trajectories))`.
 """
 struct ExpectationProblem{TS, TG, TH, TF, TP} <: AbstractUncertaintyProblem
     # defines ∫ g(S(h(x,u0,p)))*f(x)dx

--- a/src/solution_types.jl
+++ b/src/solution_types.jl
@@ -1,13 +1,15 @@
 """
-`ExpectationSolution`
+    ExpectationSolution
 
-The solution to an `ExpectationProblem`
+Container returned by `solve` for an `ExpectationProblem`.
 
 ## Fields
 
-  - `u`
-  - `resid`
-  - `original`
+  - `u`: Computed expectation value.
+  - `resid`: Residual reported by the underlying integration algorithm, or
+    `nothing` when unavailable.
+  - `original`: Original solver result returned by the underlying algorithm, or
+    `nothing` when unavailable.
 """
 struct ExpectationSolution{uType, R, O}
     u::uType

--- a/src/system_utils.jl
+++ b/src/system_utils.jl
@@ -1,11 +1,33 @@
 abstract type AbstractSystemMap end
 """
-```julia
-SystemMap(prob, args...; kwargs...)
-```
+    SystemMap(prob; kwargs...)
+    SystemMap(prob, alg; kwargs...)
+    SystemMap(prob, alg, ensemblealg; kwargs...)
 
-Representation of a system solution map for a given `prob::AbstractSciMLProblem`. `args` and `kwargs`
-are forwarded to the equation solver.
+Represent the deterministic solution map `S(u0, p)` for a SciML problem.
+
+Calling a `SystemMap` remakes `prob` with the supplied initial condition and
+parameters, then solves the remade problem.
+
+## Arguments
+
+  - `prob`: SciML problem used as the template for repeated solves.
+  - `alg`: Solver algorithm. If omitted, `solve` is called without an explicit
+    algorithm.
+  - `ensemblealg`: Ensemble algorithm used by ensemble-based expectation solves.
+    Defaults to `EnsembleThreads()`.
+  - `kwargs...`: Keyword arguments forwarded to `solve`.
+
+## Fields
+
+  - `prob`: Stored SciML problem.
+  - `alg`: Stored solver algorithm or `nothing`.
+  - `ensemblealg`: Stored ensemble algorithm.
+  - `kwargs`: Stored solver keyword arguments.
+
+## Returns
+
+A callable `SystemMap`.
 """
 struct SystemMap{
         DT <: SciMLBase.AbstractSciMLProblem,
@@ -40,13 +62,32 @@ function (sm::SystemMap{DT})(u0, p) where {DT}
 end
 
 """
-```julia
-ProcessNoiseSystemMap(prob, n, args...; kwargs...)
-```
+    ProcessNoiseSystemMap(prob, n, args...; kwargs...)
 
-Representation of a system solution map for a given `prob::SDEProblem`. `args` and `kwargs`
-are forwarded to the equation solver. `n` is the number of terms in the
-Kosambi–Karhunen–Loève representation of the process noise.
+Represent a solution map for an SDE whose process noise is parameterized by
+uncertain expansion coefficients.
+
+Calling a `ProcessNoiseSystemMap` remakes `prob` with a
+Kosambi-Karhunen-Loeve process-noise representation determined by the sampled
+coefficients and then solves the remade problem.
+
+## Arguments
+
+  - `prob`: SciML problem used as the template for repeated solves.
+  - `n`: Number of expansion terms in the process-noise representation.
+  - `args...`: Positional arguments forwarded to `solve`.
+  - `kwargs...`: Keyword arguments forwarded to `solve`.
+
+## Fields
+
+  - `prob`: Stored SciML problem.
+  - `n`: Stored number of expansion terms.
+  - `args`: Stored solver positional arguments.
+  - `kwargs`: Stored solver keyword arguments.
+
+## Returns
+
+A callable `ProcessNoiseSystemMap`.
 """
 struct ProcessNoiseSystemMap{DT <: SciMLBase.AbstractSciMLProblem, A, K} <: AbstractSystemMap
     prob::DT

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -17,3 +17,61 @@ run_qa(
     ),
     ei_broken = (:no_implicit_imports,),  # ~30 names from heavy blanket `using`; explicit-import refactor deferred: https://github.com/SciML/SciMLExpectations.jl/issues/229
 )
+
+function _owned_public_names(mod::Module)
+    public_names = Symbol[]
+    for name in names(mod; all = false, imported = true)
+        name === nameof(mod) && continue
+        isdefined(mod, name) || continue
+        value = getproperty(mod, name)
+        applicable(parentmodule, value) || continue
+        parentmodule(value) === mod || continue
+        push!(public_names, name)
+    end
+    return sort!(unique(public_names))
+end
+
+function _docstring_text(mod::Module, name::Symbol)
+    md = Docs.doc(Docs.Binding(mod, name))
+    return sprint(show, MIME"text/plain"(), md)
+end
+
+function _manual_docs_entries(mod::Module)
+    docs_src = joinpath(pkgdir(mod), "docs", "src")
+    entries = String[]
+    for (root, _, files) in walkdir(docs_src)
+        for file in files
+            endswith(file, ".md") || continue
+            in_docs_block = false
+            for line in eachline(joinpath(root, file))
+                stripped = strip(line)
+                if startswith(stripped, "```@docs") || startswith(stripped, "```@autodocs")
+                    in_docs_block = true
+                elseif startswith(stripped, "```")
+                    in_docs_block = false
+                elseif in_docs_block && !isempty(stripped) && !startswith(stripped, "#")
+                    push!(entries, stripped)
+                end
+            end
+        end
+    end
+    return entries
+end
+
+function _entry_documents_name(entry::String, name::Symbol)
+    name_string = String(name)
+    qualified_name = string(nameof(SciMLExpectations), ".", name_string)
+    return entry == name_string ||
+        startswith(entry, string(name_string, "(")) ||
+        entry == qualified_name ||
+        startswith(entry, string(qualified_name, "("))
+end
+
+@testset "public API documentation" begin
+    manual_docs_entries = _manual_docs_entries(SciMLExpectations)
+
+    for name in _owned_public_names(SciMLExpectations)
+        @test !occursin("No documentation found", _docstring_text(SciMLExpectations, name))
+        @test any(entry -> _entry_documents_name(entry, name), manual_docs_entries)
+    end
+end


### PR DESCRIPTION
## Summary

Ignore until reviewed by @ChrisRackauckas.

- Add definition-point docstrings for exported AD algorithms, expectation algorithms, system/distribution/problem types, `build_integrand`, and solution container docs.
- Add rendered manual `@docs` entries for previously omitted public API.
- Add a QA guard that checks owned public bindings have source docstrings and rendered manual docs entries while skipping reexports.

## Validation

- `git diff --check`
- `/home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e 'using Runic; exit(Runic.main(ARGS))' -- --check --diff src/problem_types.jl src/distribution_utils.jl src/system_utils.jl src/solution_types.jl src/expectation.jl test/qa/qa.jl docs/src/manual/algorithms.md docs/src/manual/solve.md`\n- focused public-doc audit: no missing source docstrings or rendered docs entries\n- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`\n- `timeout 3600 env GROUP=QA /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`\n- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path = pwd())); Pkg.instantiate(); include("docs/make.jl")'`