### PR TITLE
Make the strict-QA release non-breaking

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLExpectations"
 uuid = "afe9f18d-7609-4d0e-b7b7-af0cb72b8ea8"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "3.0.0"
+version = "2.9.0"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What this changes

| package | from | to | why |
|---|---|---|---|
| `SciMLExpectations` | 3.0.0 | 2.9.0 | QA reexport removal is not a public API break |


## Why

The version was bumped to a breaking release because the strict SciMLTesting 2.4
QA migration dropped `@reexport`s and other foreign names from the namespace.
Those names were never this package's documented public API, so re-exporting them
is not behaviour downstream users were entitled to rely on, and removing them does
not warrant a major bump. Every name the package itself exports is unchanged.

This lowers the version to the next non-breaking release instead.

Only the top-level `version` field of each `Project.toml` is touched.

After merge, each package still needs `@JuliaRegistrator register` (with
`subdir=` where applicable).